### PR TITLE
Feat: push token sending optimisation 

### DIFF
--- a/REES46/Classes/NotificationService.swift
+++ b/REES46/Classes/NotificationService.swift
@@ -32,8 +32,6 @@ public class NotificationService: NotificationServiceProtocol {
     
     public let sdk: PersonalizationSDK
     private let notificationRegistrar: NotificationRegistrar
-
-    private let mainPushTokenLastUploadDateKey = "mainPushTokenLastUploadDateKey"
     
     public init(sdk: PersonalizationSDK) {
         self.sdk = sdk

--- a/REES46/Classes/NotificationService.swift
+++ b/REES46/Classes/NotificationService.swift
@@ -32,7 +32,6 @@ public class NotificationService: NotificationServiceProtocol {
     
     public let sdk: PersonalizationSDK
     
-    //MARK: - private properties
     private let mainPushTokenLastUploadDateKey = "mainPushTokenLastUploadDateKey"
     
     public init(sdk: PersonalizationSDK) {
@@ -54,7 +53,7 @@ public class NotificationService: NotificationServiceProtocol {
               sdk.autoSendPushToken == true
         else { return }
         
-        if let pushTokenLastUpdateDate = UserDefaults.standard.value(forKey: self.mainPushTokenLastUploadDateKey) as? Date {
+        if let pushTokenLastUpdateDate = UserDefaults.standard.object(forKey: self.mainPushTokenLastUploadDateKey) as? Date {
             let currentDate = Date()
             let timeSincePushTokenLastUpdate = currentDate.timeIntervalSince(pushTokenLastUpdateDate)
             let oneWeekInSeconds: TimeInterval = 7 * 24 * 60 * 60

--- a/REES46/Classes/PersonalizationSDK.swift
+++ b/REES46/Classes/PersonalizationSDK.swift
@@ -267,8 +267,8 @@ public extension PersonalizationSDK {
 }
 
 
-public func createPersonalizationSDK(shopId: String, userEmail: String? = nil, userPhone: String? = nil, userLoyaltyId: String? = nil, apiDomain: String = "api.rees46.com", stream: String = "ios", enableLogs: Bool = false, _ completion: ((SDKError?) -> Void)? = nil) -> PersonalizationSDK {
-    let sdk = SimplePersonalizationSDK(shopId: shopId, userEmail: userEmail, userPhone: userPhone, userLoyaltyId: userLoyaltyId, apiDomain: apiDomain, stream: stream, enableLogs: enableLogs, completion: completion)
+public func createPersonalizationSDK(shopId: String, userEmail: String? = nil, userPhone: String? = nil, userLoyaltyId: String? = nil, apiDomain: String = "api.rees46.com", stream: String = "ios", enableLogs: Bool = false, autoSendPushToken: Bool = true, _ completion: ((SDKError?) -> Void)? = nil) -> PersonalizationSDK {
+    let sdk = SimplePersonalizationSDK(shopId: shopId, userEmail: userEmail, userPhone: userPhone, userLoyaltyId: userLoyaltyId, apiDomain: apiDomain, stream: stream, enableLogs: enableLogs, autoSendPushToken: autoSendPushToken, completion: completion)
     
     sdk.resetSdkCache()
     

--- a/REES46/Classes/SimplePersonalizationSDK.swift
+++ b/REES46/Classes/SimplePersonalizationSDK.swift
@@ -46,15 +46,7 @@ class SimplePersonalizationSDK: PersonalizationSDK {
     private let initSemaphore = DispatchSemaphore(value: 0)
     private let serialSemaphore = DispatchSemaphore(value: 0)
 
-    init(shopId: String, 
-         userEmail: String? = nil,
-         userPhone: String? = nil,
-         userLoyaltyId: String? = nil,
-         apiDomain: String,
-         stream: String = "ios",
-         enableLogs: Bool = false,
-         autoSendPushToken: Bool = true,
-         completion: ((SDKError?) -> Void)? = nil) {
+    init(shopId: String, userEmail: String? = nil, userPhone: String? = nil, userLoyaltyId: String? = nil, apiDomain: String, stream: String = "ios", enableLogs: Bool = false, autoSendPushToken: Bool = true, completion: ((SDKError?) -> Void)? = nil) {
         self.shopId = shopId
         self.autoSendPushToken = autoSendPushToken
         

--- a/REES46/Classes/SimplePersonalizationSDK.swift
+++ b/REES46/Classes/SimplePersonalizationSDK.swift
@@ -22,6 +22,7 @@ class SimplePersonalizationSDK: PersonalizationSDK {
     
     var baseURL: String
     let baseInitJsonFileName = ".json"
+    let autoSendPushToken: Bool
     
     let sdkBundleId = Bundle(for: SimplePersonalizationSDK.self).bundleIdentifier
     let appBundleId = Bundle(for: SimplePersonalizationSDK.self).bundleIdentifier
@@ -45,8 +46,17 @@ class SimplePersonalizationSDK: PersonalizationSDK {
     private let initSemaphore = DispatchSemaphore(value: 0)
     private let serialSemaphore = DispatchSemaphore(value: 0)
 
-    init(shopId: String, userEmail: String? = nil, userPhone: String? = nil, userLoyaltyId: String? = nil, apiDomain: String, stream: String = "ios", enableLogs: Bool = false, completion: ((SDKError?) -> Void)? = nil) {
+    init(shopId: String, 
+         userEmail: String? = nil,
+         userPhone: String? = nil,
+         userLoyaltyId: String? = nil,
+         apiDomain: String,
+         stream: String = "ios",
+         enableLogs: Bool = false,
+         autoSendPushToken: Bool = true,
+         completion: ((SDKError?) -> Void)? = nil) {
         self.shopId = shopId
+        self.autoSendPushToken = autoSendPushToken
         
         global_EL = enableLogs
         self.baseURL = "https://" + apiDomain + "/"

--- a/REES46/Classes/services/notification/events/RegisterNotification.swift
+++ b/REES46/Classes/services/notification/events/RegisterNotification.swift
@@ -1,0 +1,48 @@
+import Foundation
+import UIKit
+
+class NotificationRegistrar {
+    private let sdk: PersonalizationSDK
+    private let mainPushTokenLastUploadDateKey = "mainPushTokenLastUploadDateKey"
+
+    init(sdk: PersonalizationSDK) {
+        self.sdk = sdk
+    }
+
+    func registerWithDeviceToken(deviceToken: Data) {
+        guard let sdk = sdk as? SimplePersonalizationSDK,
+              sdk.autoSendPushToken == true
+        else { return }
+
+        if let pushTokenLastUpdateDate = UserDefaults.standard.object(forKey: self.mainPushTokenLastUploadDateKey) as? Date {
+            let currentDate = Date()
+            let timeSincePushTokenLastUpdate = currentDate.timeIntervalSince(pushTokenLastUpdateDate)
+            let oneWeekInSeconds: TimeInterval = 7 * 24 * 60 * 60
+
+            guard timeSincePushTokenLastUpdate >= oneWeekInSeconds else {
+                return
+            }
+        }
+
+        let token = deviceToken.map { String(format: "%02.2hhx", $0) }.joined()
+        sdk.setPushTokenNotification(token: token) { [weak self] tokenResponse in
+            guard let self = self else { return }
+            switch tokenResponse {
+            case .success():
+                UserDefaults.standard.setValue(Date(), forKey: self.mainPushTokenLastUploadDateKey)
+                return
+            case .failure(let error):
+                self.handleRegistrationError(error)
+            }
+        }
+    }
+
+    private func handleRegistrationError(_ error: NotificationError) {
+        switch error {
+        case let .custom(customError):
+            print("SDK Push Token Error:", customError)
+        default:
+            print("SDK Push Token server, \(error.description)\n")
+        }
+    }
+}

--- a/REES46/Classes/services/notification/events/RegisterNotification.swift
+++ b/REES46/Classes/services/notification/events/RegisterNotification.swift
@@ -37,7 +37,7 @@ class NotificationRegistrar {
         }
     }
 
-    private func handleRegistrationError(_ error: NotificationError) {
+    private func handleRegistrationError(_ error: SDKError) {
         switch error {
         case let .custom(customError):
             print("SDK Push Token Error:", customError)


### PR DESCRIPTION
added a flag to automatically send tokens (enabled by default), after initialization SDK checks when the last time a token was sent 
[https://github.com/rees46/planning/issues/271](https://github.com/rees46/planning/issues/271)