### PR TITLE
Feature: text block views in stories

### DIFF
--- a/REES46/Classes/Model/Stories.swift
+++ b/REES46/Classes/Model/Stories.swift
@@ -253,6 +253,17 @@ class Slide {
 public class StoriesElement {
     public var link: String?
     public var deeplinkIos: String?
+    let uID: String?
+    let fontType: FontType?
+    let fontSize: Double?
+    let textItalic: Bool?
+    let textBackgroundColorOpacity: String?
+    private(set) var textBackgroundColor: UIColor?
+    let textColor: UIColor?
+    let textInput: String?
+    let textAlignment: String?
+    let textLineSpacing: Double?
+    let yOffset: Double?
     let type: ElementType
     let color: String?
     let title, linkIos: String?
@@ -266,12 +277,23 @@ public class StoriesElement {
     public init(json: [String: Any]) {
         self.link = json["link"] as? String
         self.deeplinkIos = json["deeplink_ios"] as? String
+        self.fontType = FontType(rawValue: json["font_type"] as? String ?? "")
+        self.fontSize = Double(json["font_size"] as? String ?? "")
+        self.textItalic = json["italic"] as? Bool ?? false
+        self.textBackgroundColorOpacity = json["text_background_color_opacity"] as? String
+        self.textBackgroundColor = UIColor(hexString: json["text_background_color"] as? String ?? "")
+        self.textColor = UIColor(hexString: json["text_color"] as? String ?? "")
+        self.textInput = json["text_input"] as? String
+        self.textAlignment = json["text_align"] as? String
+        self.textLineSpacing = Double(json["text_line_spacing"] as? String ?? "1.5")
+        self.yOffset = Double(json["y_offset"] as? String ?? "")
+        self.uID = json["uniqid"] as? String
         let _type = json["type"] as? String ?? ""
         self.type = ElementType(rawValue: _type) ?? .unknown
         self.color = json["color"] as? String
         self.title = json["title"] as? String
         self.linkIos = json["link_ios"] as? String
-        self.textBold = json["text_bold"] as? Bool
+        self.textBold = json["text_bold"] as? Bool ?? json["bold"] as? Bool
         self.background = json["background"] as? String
         self.cornerRadius = json["corner_radius"] as? Int ?? 12
         let _labels = json["labels"] as? [String: Any] ?? [:]
@@ -280,6 +302,23 @@ public class StoriesElement {
         self.products = _products.map({StoriesProduct(json: $0)})
         let _product = json["item"] as? [String: Any] ?? [:]
         self.product = StoriesPromoCodeElement(json: _product)
+        
+        applyTextBackgroundOpacity()
+    }
+    
+    private func applyTextBackgroundOpacity() {
+        guard let opacityString = textBackgroundColorOpacity,
+              let opacityValue = extractOpacity(from: opacityString),
+              let color = textBackgroundColor else { return }
+        self.textBackgroundColor = color.withAlphaComponent(opacityValue)
+    }
+    
+    private func extractOpacity(from opacityString: String) -> CGFloat? {
+        let percentageString = opacityString.trimmingCharacters(in: CharacterSet(charactersIn: "%"))
+        if let percentage = Double(percentageString) {
+            return CGFloat(percentage) / 100.0
+        }
+        return nil
     }
 }
 
@@ -401,6 +440,14 @@ enum ElementType: String {
     case button = "button"
     case products = "products"
     case product = "product"
+    case textBlock = "text_block"
+    case unknown
+}
+
+enum FontType: String {
+    case monospaced = "monospaced"
+    case serif = "serif"
+    case sansSerif = "sans-serif"
     case unknown
 }
 

--- a/REES46/Classes/Stories/StoryViewController/CollectionViewCell/StoryCollectionViewCell.swift
+++ b/REES46/Classes/Stories/StoryViewController/CollectionViewCell/StoryCollectionViewCell.swift
@@ -117,73 +117,48 @@ class StoryCollectionViewCell: UICollectionViewCell {
         
         promocodeBannerView.removeFromSuperview()
         insertSubview(productWithPromocodeSuperview, belowSubview: storySlideImageView)
+        self.subviews.filter { $0 is TextBlockView }.forEach { $0.removeFromSuperview() }
         
         if slide.type == .video {
-            videoView.isHidden = false
-            storySlideImageView.isHidden = true
-            
-            self.videoView.layer.sublayers?.forEach {
-                if $0.name == "VIDEO" {
-                    $0.removeFromSuperlayer()
-                }
-            }
-            if let videoURL = slide.videoURL {
-                videoView.isHidden = false
-                storySlideImageView.isHidden = true
-
-                let asset = AVAsset(url: videoURL)
-                let playerItem = AVPlayerItem(asset: asset)
-                self.player = AVPlayer(playerItem: playerItem)
-                let playerLayer = AVPlayerLayer(player: player)
-                let screenSize = UIScreen.main.bounds.size
-                playerLayer.frame = CGRect(x: 0, y: 0, width: screenSize.width, height: screenSize.height)
-                playerLayer.name = "VIDEO"
-                
-                if playerItem.asset.tracks.filter({$0.mediaType == .audio}).count != 0 {
-                    let soundSetting: Bool = UserDefaults.standard.bool(forKey: "MuteSoundSetting")
-                    var frameworkBundle = Bundle(for: classForCoder)
-#if SWIFT_PACKAGE
-                    frameworkBundle = Bundle.module
-#endif
-                    if soundSetting {
-                        player.volume = 1
-                        muteButton.setImage(UIImage(named: "iconStoryVolumeUp", in: frameworkBundle, compatibleWith: nil), for: .normal)
-                        UserDefaults.standard.set(true, forKey: "MuteSoundSetting")
-                        
-                        do {
-                            try audioSession.setCategory(.playback, mode: .default, options: [])
-                        } catch let error {
-                            print("SDK Error in AVAudio Session\(error.localizedDescription)")
-                        }
-                    } else {
-                        player.volume = 0
-                        muteButton.setImage(UIImage(named: "iconStoryMute", in: frameworkBundle, compatibleWith: nil), for: .normal)
-                        UserDefaults.standard.set(false, forKey: "MuteSoundSetting")
-                    }
-                    muteButton.isHidden = false
-                } else {
-                    muteButton.isHidden = true
-                }
-                self.videoView.layer.addSublayer(playerLayer)
-                player.play()
-                UserDefaults.standard.set(currentSlide!.id, forKey: "LastViewedSlideMemorySetting")
-            } else {
-                muteButton.isHidden = true
-                storySlideImageView.isHidden = false
-                videoView.isHidden = true
-                if let preview = slide.previewImage {
-                    self.storySlideImageView.image = preview
-                }
-            }
+            configureVideoView(for: slide)
         } else {
-            muteButton.isHidden = true
-            storySlideImageView.isHidden = false
-            videoView.isHidden = true
-            if let image = slide.downloadedImage {
-                self.storySlideImageView.image = image
-            }
+            configureImageView(for: slide)
         }
         
+        let textBlockViews: [TextBlockView] = slide.elements
+            .filter { $0.type == .textBlock }
+            .map { TextBlockView(textBlockObject: $0) }
+        if !textBlockViews.isEmpty {
+            configure(textBlockViews, for: slide)
+        }
+        
+        configureButtons(for: slide)
+        
+        bringSubviewsToFront([storyButton, productsButton, muteButton, productWithPromocodeSuperview, promocodeBannerView])
+    }
+    
+    private func bringSubviewsToFront(_ subviews: [UIView]) {
+        subviews.forEach { bringSubviewToFront($0) }
+    }
+    
+    private func configure(_ textBlockViews: [TextBlockView], for slide: Slide) {
+        textBlockViews.enumerated().forEach { [weak self] (index, textBlockView) in
+            guard let self = self else { return }
+            textBlockView.translatesAutoresizingMaskIntoConstraints = false
+            
+            self.addSubview(textBlockView)
+            
+            guard let yOffset = textBlockView.textBlockObject.yOffset else { return }
+            
+            NSLayoutConstraint.activate([
+                textBlockView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 20),
+                textBlockView.trailingAnchor.constraint(lessThanOrEqualTo: self.trailingAnchor, constant: -20),
+                textBlockView.topAnchor.constraint(equalTo: self.safeAreaLayoutGuide.topAnchor, constant: ((self.bounds.size.height / 10) + CGFloat(yOffset)))
+            ])
+        }
+    }
+    
+    private func configureButtons(for slide: Slide) {
         if let element = slide.elements.first(where: {$0.type == .button}) {
             UserDefaults.standard.set(false, forKey: "DoubleProductButtonSetting")
             selectedElement = element
@@ -272,6 +247,60 @@ class StoryCollectionViewCell: UICollectionViewCell {
             productsButton.isHidden = true
             productWithPromocodeSuperview.isHidden = true
             makeConstraints()
+        }
+    }
+    
+    private func configureVideoView(for slide: Slide) {
+        videoView.isHidden = false
+        storySlideImageView.isHidden = true
+        videoView.layer.sublayers?.forEach { $0.name == "VIDEO" ? $0.removeFromSuperlayer() : () }
+        
+        if let videoURL = slide.videoURL {
+            let asset = AVAsset(url: videoURL)
+            let playerItem = AVPlayerItem(asset: asset)
+            player = AVPlayer(playerItem: playerItem)
+            let playerLayer = AVPlayerLayer(player: player)
+            playerLayer.frame = bounds
+            playerLayer.name = "VIDEO"
+            
+            if asset.tracks(withMediaType: .audio).count > 0 {
+                let soundSetting: Bool = UserDefaults.standard.bool(forKey: "MuteSoundSetting")
+                player.volume = soundSetting ? 1 : 0
+                muteButton.isHidden = false
+                updateMuteButtonImage(isMuted: !soundSetting)
+            } else {
+                muteButton.isHidden = true
+            }
+
+            self.videoView.layer.addSublayer(playerLayer)
+            player.play()
+            UserDefaults.standard.set(currentSlide!.id, forKey: "LastViewedSlideMemorySetting")
+        } else {
+            muteButton.isHidden = true
+            storySlideImageView.isHidden = false
+            videoView.isHidden = true
+            if let preview = slide.previewImage {
+                self.storySlideImageView.image = preview
+            }
+        }
+    }
+    
+    private func updateMuteButtonImage(isMuted: Bool) {
+           var frameworkBundle = Bundle(for: classForCoder)
+   #if SWIFT_PACKAGE
+           frameworkBundle = Bundle.module
+   #endif
+           let imageName = isMuted ? "iconStoryMute" : "iconStoryVolumeUp"
+           muteButton.setImage(UIImage(named: imageName, in: frameworkBundle, compatibleWith: nil), for: .normal)
+       }
+    
+    private func configureImageView(for slide: Slide) {
+        muteButton.isHidden = true
+        storySlideImageView.isHidden = false
+        videoView.isHidden = true
+        
+        if let image = slide.downloadedImage {
+            storySlideImageView.image = image
         }
     }
     

--- a/REES46/Classes/Stories/TextBlockView/TextBlockView.swift
+++ b/REES46/Classes/Stories/TextBlockView/TextBlockView.swift
@@ -1,0 +1,84 @@
+import UIKit
+import Foundation
+
+class TextBlockView: UIView {
+    
+    let textBlockObject: StoriesElement
+    
+    private let label: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = 0
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    init(textBlockObject: StoriesElement) {
+        self.textBlockObject = textBlockObject
+        super.init(frame: .zero)
+        setupView()
+        
+        let fontType = textBlockObject.fontType ?? .unknown
+        let fontSize = textBlockObject.fontSize ?? 14
+        let fontMap: [FontType: String] = [
+            .monospaced: "Menlo",
+            .serif: "Georgia",
+            .sansSerif: "Arial",
+            .unknown: "Helvetica-Neue"
+        ]
+        
+        let fontName = fontMap[fontType] ?? "Helvetica-Neue"
+        var fontDescriptor = UIFontDescriptor(name: fontName, size: fontSize)
+        
+        if textBlockObject.textBold == true {
+            fontDescriptor = fontDescriptor.withSymbolicTraits(.traitBold) ?? fontDescriptor
+        }
+        
+        if textBlockObject.textItalic == true {
+            fontDescriptor = fontDescriptor.withSymbolicTraits(.traitItalic) ?? fontDescriptor
+        }
+        
+        label.font = UIFont(descriptor: fontDescriptor, size: fontSize)
+        print(label.font.fontName)
+        
+        
+        label.textColor = textBlockObject.textColor
+        self.layer.cornerRadius = 5
+        self.clipsToBounds = true
+        self.backgroundColor = textBlockObject.textBackgroundColor
+        label.textAlignment = {
+            switch textBlockObject.textAlignment {
+            case "left":
+                return .left
+            case "right":
+                return .right
+            case "center":
+                return .center
+            default:
+                return .left
+            }
+        }()
+        
+        if let textLineSpacing = textBlockObject.textLineSpacing {
+            let paragraphStyle = NSMutableParagraphStyle()
+            paragraphStyle.lineSpacing = textLineSpacing
+            let attributedText = NSAttributedString(string: textBlockObject.textInput ?? "", attributes: [NSAttributedString.Key.paragraphStyle: paragraphStyle])
+            label.attributedText = attributedText
+        } else {
+            label.text = textBlockObject.textInput
+        }
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupView() {
+        addSubview(label)
+        NSLayoutConstraint.activate([
+            label.topAnchor.constraint(equalTo: topAnchor, constant: 2),
+            label.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -2),
+            label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 5),
+            label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -5)
+        ])
+    }
+}


### PR DESCRIPTION
updated model & created view for textBlock `StoriesElement` made refactoring of function `configure(slide: Slide)` and broke it to smaller functions 

https://github.com/rees46/ios-sdk/assets/62468960/2d98c661-28a5-4fad-ad09-d990cd6b8f52

this behaviour works with `storyButton`, `productsButton`, `muteButton`, `productWithPromocodeSuperview`, `promocodeBannerView`


